### PR TITLE
Fixed reference to non-existant jQuery in scope

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1868,7 +1868,7 @@
 
         _.animating = true;
 
-        var beforeChangeEvent = jQuery.Event("beforeChange");
+        var beforeChangeEvent = $.Event("beforeChange");
         _.$slider.trigger(beforeChangeEvent, [_, _.currentSlide, animSlide]);
         if(beforeChangeEvent.isDefaultPrevented()){
             _.animating = false;


### PR DESCRIPTION
kenwheeler/slick#1139

In Browserify/Commonjs, `jQuery` doesn't exist.
